### PR TITLE
Update bibliographic items according to IHO website

### DIFF
--- a/data/b-12_3-0-0.yaml
+++ b/data/b-12_3-0-0.yaml
@@ -1,0 +1,67 @@
+---
+title:
+- type: main
+  content: Guidance on Crowdsourced Bathymetry
+  language: en
+- type: main
+  content: Document d'orientation sur la bathymétrie participative
+  language: fr
+editorialgroup:
+- - committee:
+      abbreviation: IRCC
+      name: Inter-Regional Coordination Committee
+  - committee:
+      abbreviation: DCDB
+      name: IHO Data Centre for Digital Bathymetry
+type: standard
+docid:
+  type: IHO
+  id: B-12
+  primary: true
+docnumber: 12
+edition:
+  content: 3.0.0
+docstatus:
+  stage:
+    value: in-force
+language:
+- en
+- fr
+script: Latn
+version:
+  revision_date: '2022-10-01'
+date:
+  type: published
+  from: '2022-10-01'
+copyright:
+- owner:
+    name: International Hydrographic Organization
+    abbreviation: IHO
+    url: www.iho.int
+  from: '2020'
+link:
+- type: pdf
+  content: https://iho.int/uploads/user/pubs/bathy/B_12_Ed2.0.3_2020.pdf
+place: Monaco
+validity:
+  begins: '2022-10-01'
+contributor:
+- organization:
+    name: International Hydrographic Organization
+    abbreviation: IHO
+    url: www.iho.int
+  role: publisher
+series:
+  number: B
+  type: main
+  title:
+    type: original
+    content:
+    - content: Bathymetric Publications
+      language: en
+      script: Latn
+    - content: Publications bathymétriques
+      language: fr
+      script: Latn
+  place: Monaco
+  organization: International Hydrographic Organization

--- a/data/c-17_3-0-0.yaml
+++ b/data/c-17_3-0-0.yaml
@@ -1,0 +1,60 @@
+---
+title:
+- type: main
+  content: SPATIAL DATA INFRASTRUCTURES "THE MARINE DIMENSION"
+  language: en
+type: standard
+editorialgroup:
+- - committee:
+      abbreviation: IRCC
+      name: Inter-Regional Coordination Committee
+      workgroup:
+        abbreviation: MSDIWG
+        name: MARINE SPATIAL DATA INFRASTRUCTURES WORKING GROUP
+docid:
+  type: IHO
+  id: C-17
+  primary: true
+docnumber: 17
+edition:
+  content: 3.0.0
+docstatus:
+  stage:
+    value: in-force
+language:
+- en
+script: Latn
+version:
+  revision_date: '2023-10-01'
+date:
+  type: published
+  from: '2023-10-01'
+copyright:
+- owner:
+    name: International Hydrographic Organization
+    abbreviation: IHO
+    url: www.iho.int
+  from: '2023'
+link:
+- type: pdf
+  content: https://iho.int/uploads/user/pubs/cb/c-17/C-17%20Ed%203.0.0_October%202023_Final.pdf
+place: Monaco
+validity:
+  begins: '2023-10-01'
+contributor:
+- organization:
+    name: International Hydrographic Organization
+    abbreviation: IHO
+    url: www.iho.int
+  role: publisher
+series:
+  number: C
+  type: main
+  title:
+    type: original
+    content:
+    - content: Capacity Building Publications
+      language: en
+      script: Latn
+  place: Monaco
+  organization: International Hydrographic Organization

--- a/data/m-1_2-1-1.yaml
+++ b/data/m-1_2-1-1.yaml
@@ -1,0 +1,61 @@
+---
+title:
+- type: main
+  content: BASIC DOCUMENTS OF THE INTERNATIONAL HYDROGRAPHIC ORGANIZATION (IHO)
+  language: en
+- type: main
+  content: DOCUMENTS DE BASE DE L’ORGANISATION HYDROGRAPHIQUE INTERNATIONALE (OHI)
+  language: fr
+editorialgroup:
+- committee:
+    abbreviation: BUREAU
+    name: International Hydrography Bureau
+type: standard
+docid:
+  type: IHO
+  id: M-1
+  primary: true
+docnumber: 1
+edition:
+  content: 2.1.1
+docstatus:
+  stage:
+    value: in-force
+language:
+- en
+- fr
+script: Latn
+version:
+  revision_date: '2020-06-25'
+date:
+  type: published
+  from: '2020-06-25'
+copyright:
+- owner:
+    name: International Hydrographic Organization
+    abbreviation: IHO
+    url: www.iho.int
+  from: '2020'
+place: Monaco
+validity:
+  begins: '2020-06-25'
+contributor:
+- organization:
+    name: International Hydrographic Organization
+    abbreviation: IHO
+    url: www.iho.int
+  role: publisher
+series:
+  number: M
+  type: main
+  title:
+    type: original
+    content:
+    - content: Miscellaneous Publications
+      language: en
+      script: Latn
+    - content: Publications Mixtes
+      language: fr
+      script: Latn
+  place: Monaco
+  organization: International Hydrographic Organization

--- a/data/m-1_2-1-2.yaml
+++ b/data/m-1_2-1-2.yaml
@@ -1,0 +1,61 @@
+---
+title:
+- type: main
+  content: BASIC DOCUMENTS OF THE INTERNATIONAL HYDROGRAPHIC ORGANIZATION (IHO)
+  language: en
+- type: main
+  content: DOCUMENTS DE BASE DE L’ORGANISATION HYDROGRAPHIQUE INTERNATIONALE (OHI)
+  language: fr
+editorialgroup:
+- committee:
+    abbreviation: BUREAU
+    name: International Hydrography Bureau
+type: standard
+docid:
+  type: IHO
+  id: M-1
+  primary: true
+docnumber: 1
+edition:
+  content: 2.1.2
+docstatus:
+  stage:
+    value: in-force
+language:
+- en
+- fr
+script: Latn
+version:
+  revision_date: '2023-03-31'
+date:
+  type: published
+  from: '2023-03-31'
+copyright:
+- owner:
+    name: International Hydrographic Organization
+    abbreviation: IHO
+    url: www.iho.int
+  from: '2023'
+place: Monaco
+validity:
+  begins: '2023-03-31'
+contributor:
+- organization:
+    name: International Hydrographic Organization
+    abbreviation: IHO
+    url: www.iho.int
+  role: publisher
+series:
+  number: M
+  type: main
+  title:
+    type: original
+    content:
+    - content: Miscellaneous Publications
+      language: en
+      script: Latn
+    - content: Publications Mixtes
+      language: fr
+      script: Latn
+  place: Monaco
+  organization: International Hydrographic Organization

--- a/data/m-1_2-1-3.yaml
+++ b/data/m-1_2-1-3.yaml
@@ -1,0 +1,64 @@
+---
+title:
+- type: main
+  content: BASIC DOCUMENTS OF THE INTERNATIONAL HYDROGRAPHIC ORGANIZATION (IHO)
+  language: en
+- type: main
+  content: DOCUMENTS DE BASE DE L’ORGANISATION HYDROGRAPHIQUE INTERNATIONALE (OHI)
+  language: fr
+editorialgroup:
+- committee:
+    abbreviation: BUREAU
+    name: International Hydrography Bureau
+type: standard
+docid:
+  type: IHO
+  id: M-1
+  primary: true
+docnumber: 1
+edition:
+  content: 2.1.3
+docstatus:
+  stage:
+    value: in-force
+language:
+- en
+- fr
+script: Latn
+version:
+  revision_date: '2024-01-01'
+date:
+  type: published
+  from: '2024-01-01'
+copyright:
+- owner:
+    name: International Hydrographic Organization
+    abbreviation: IHO
+    url: www.iho.int
+  from: '2024'
+link:
+- type: pdf
+  content: https://iho.int/uploads/user/pubs/misc/M_1_EN_012024.pdf
+place: Monaco
+validity:
+  begins: '2024-01-01'
+contributor:
+- organization:
+    name: International Hydrographic Organization
+    abbreviation: IHO
+    url: www.iho.int
+  role: publisher
+series:
+  number: M
+  type: main
+  title:
+    type: original
+    content:
+    - content: Miscellaneous Publications
+      language: en
+      script: Latn
+    - content: Publications Mixtes
+      language: fr
+      script: Latn
+  place: Monaco
+  organization: International Hydrographic Organization

--- a/data/m-3_2-0-0.yaml
+++ b/data/m-3_2-0-0.yaml
@@ -42,7 +42,7 @@ copyright:
   from: '2020'
 link:
 - type: pdf
-  content: https://iho.int/uploads/user/pubs/misc/M3-E-30_03_2020.pdf
+  content: https://iho.int/uploads/user/pubs/misc/M3-E-2023%20-%20July.pdf
 place: Monaco
 validity:
   begins: '2020-03-01'

--- a/data/m-7_9-0-0.yaml
+++ b/data/m-7_9-0-0.yaml
@@ -1,0 +1,64 @@
+---
+title:
+- type: main
+  content: Staff Regulation
+  language: en
+- type: main
+  content: Règlement du personnel
+  language: fr
+editorialgroup:
+- - committee:
+      abbreviation: IHR
+      name: International Hydrography Review
+type: standard
+docid:
+  type: IHO
+  id: M-7
+  primary: true
+docnumber: 7
+edition:
+  content: 9.0.0
+docstatus:
+  stage:
+    value: in-force
+language:
+- en
+- fr
+script: Latn
+version:
+  revision_date: '2023-07-01'
+date:
+  type: published
+  from: '2023-07-01'
+copyright:
+- owner:
+    name: International Hydrographic Organization
+    abbreviation: IHO
+    url: www.iho.int
+  from: '2023'
+link:
+- type: pdf
+  content: https://iho.int/uploads/user/pubs/misc/M-7_v9_2023_ENG.pdf
+place: Monaco
+validity:
+  begins: '2023-07-01'
+contributor:
+- organization:
+    name: International Hydrographic Organization
+    abbreviation: IHO
+    url: www.iho.int
+  role: publisher
+series:
+  number: M
+  type: main
+  title:
+    type: original
+    content:
+    - content: Miscellaneous Publications
+      language: en
+      script: Latn
+    - content: Publications Mixtes
+      language: fr
+      script: Latn
+  place: Monaco
+  organization: International Hydrographic Organization

--- a/data/p-1-30.yaml
+++ b/data/p-1-30.yaml
@@ -1,0 +1,61 @@
+---
+title:
+- type: main
+  content: International Hydrographic Review
+  language: en
+editorialgroup:
+- - committee:
+      abbreviation: IHR
+      name: International Hydrography Review
+type: standard
+docid:
+  type: IHO
+  id: P-1/30
+  # number: 30
+  primary: true
+docnumber: 1
+edition:
+docstatus:
+  stage:
+    value: in-force
+language:
+- en
+script: Latn
+version:
+  revision_date: '2024-05-01'
+date:
+  type: published
+  from: '2024-05-01'
+copyright:
+- owner:
+    name: International Hydrographic Organization
+    abbreviation: IHO
+    url: www.iho.int
+  from: '2024'
+link:
+- type: pdf
+  content: https://ihr.iho.int/wp-content/uploads/2024/05/IHR-30-1.pdf
+place: Monaco
+validity:
+  begins: '1923-01-01'
+contributor:
+- organization:
+    name: International Hydrographic Organization
+    abbreviation: IHO
+    url: www.iho.int
+  role: publisher
+series:
+  type: main
+  formattedref:
+    content: IHO P-1
+  title:
+    type: original
+    content:
+    - content: International Hydrographic Review
+      language: en
+      script: Latn
+  place: Monaco
+  organization: International Hydrographic Organization
+  abbreviation: IHR
+  from: '1923-01-01'
+  # issn: 0020-6946

--- a/data/p-5.yaml
+++ b/data/p-5.yaml
@@ -29,7 +29,7 @@ language:
 - es
 script: Latn
 version:
-  revision_date: '2020-06-01'
+  revision_date: '2024-07-01'
 date:
   type: published
   from: '2020-06-01'

--- a/data/p-6-3.yaml
+++ b/data/p-6-3.yaml
@@ -1,0 +1,56 @@
+---
+title:
+- type: main
+  content: 3rd SESSION OF THE IHO ASSEMBLY
+  language: en
+editorialgroup:
+- - committee:
+      abbreviation: IHR
+      name: International Hydrography Review
+type: standard
+docid:
+  type: IHO
+  id: P-6
+  primary: true
+docnumber: 6
+edition:
+docstatus:
+  stage:
+    value: in-force
+language:
+- en
+script: Latn
+version:
+  revision_date: '2023-05-05'
+date:
+  type: published
+  from: '2023-05-05'
+copyright:
+- owner:
+    name: International Hydrographic Organization
+    abbreviation: IHO
+    url: www.iho.int
+  from: '2023'
+link:
+- type: pdf
+  content: https://iho.int/uploads/user/pubs/periodical/P6A1_2023VOLUME2_ENG_opt.pdf
+place: Monaco
+validity:
+  begins: '2023-05-05'
+contributor:
+- organization:
+    name: International Hydrographic Organization
+    abbreviation: IHO
+    url: www.iho.int
+  role: publisher
+series:
+  number: P
+  type: main
+  title:
+    type: original
+    content:
+    - content: Periodic Publications
+      language: en
+      script: Latn
+  place: Monaco
+  organization: International Hydrographic Organization

--- a/data/p-7_1-0-7.yaml
+++ b/data/p-7_1-0-7.yaml
@@ -1,0 +1,56 @@
+---
+title:
+- type: main
+  content: IHO Annual Report - 2018 Part 1 & 2
+  language: en
+editorialgroup:
+- - committee:
+      abbreviation: IHR
+      name: International Hydrography Review
+type: standard
+docid:
+  type: IHO
+  id: P-7
+  primary: true
+docnumber: 7
+edition:
+  content: 1.0.7
+docstatus:
+  stage:
+    value: in-force
+language:
+- en
+- fr
+- es
+script: Latn
+version:
+  revision_date: '2020-05-01'
+date:
+  type: published
+  from: '2020-05-01'
+copyright:
+- owner:
+    name: International Hydrographic Organization
+    abbreviation: IHO
+    url: www.iho.int
+  from: '2019'
+place: Monaco
+validity:
+  begins: '2020-05-01'
+contributor:
+- organization:
+    name: International Hydrographic Organization
+    abbreviation: IHO
+    url: www.iho.int
+  role: publisher
+series:
+  number: P
+  type: main
+  title:
+    type: original
+    content:
+    - content: Periodic Publications
+      language: en
+      script: Latn
+  place: Monaco
+  organization: International Hydrographic Organization

--- a/data/p-7_1-0-8.yaml
+++ b/data/p-7_1-0-8.yaml
@@ -1,0 +1,59 @@
+---
+title:
+- type: main
+  content: IHO Annual Report - 2018 Part 1 & 2
+  language: en
+editorialgroup:
+- - committee:
+      abbreviation: IHR
+      name: International Hydrography Review
+type: standard
+docid:
+  type: IHO
+  id: P-7
+  primary: true
+docnumber: 7
+edition:
+  content: 1.0.8
+docstatus:
+  stage:
+    value: in-force
+language:
+- en
+- fr
+- es
+script: Latn
+version:
+  revision_date: '2024-04-01'
+date:
+  type: published
+  from: '2024-04-01'
+copyright:
+- owner:
+    name: International Hydrographic Organization
+    abbreviation: IHO
+    url: www.iho.int
+  from: '2019'
+link:
+- type: pdf
+  content: https://iho.int/uploads/user/pubs/periodical/P7_2023_EN.pdf
+place: Monaco
+validity:
+  begins: '2024-04-01'
+contributor:
+- organization:
+    name: International Hydrographic Organization
+    abbreviation: IHO
+    url: www.iho.int
+  role: publisher
+series:
+  number: P
+  type: main
+  title:
+    type: original
+    content:
+    - content: Periodic Publications
+      language: en
+      script: Latn
+  place: Monaco
+  organization: International Hydrographic Organization

--- a/data/s-104_1-1-0.yaml
+++ b/data/s-104_1-1-0.yaml
@@ -1,0 +1,63 @@
+---
+title:
+- type: main
+  content: Water Level Information for Surface Navigation
+  language: en
+editorialgroup:
+- - committee:
+      abbreviation: HSSC
+      name: Hydrographic Services and Standards Committee
+      workgroup:
+        abbreviation: S-100WG
+        name: S-100 Working Group
+type: standard
+docid:
+  type: IHO
+  id: S-104
+  primary: true
+docnumber: 104
+edition:
+  content: 1.1.0
+docstatus:
+  stage:
+    value: in-force
+language:
+- en
+script: Latn
+version:
+  revision_date: '2023-04-10'
+date:
+  type: published
+  from: '2023-04-10'
+copyright:
+- owner:
+    name: International Hydrographic Organization
+    abbreviation: IHO
+    url: www.iho.int
+  from: '2023'
+link:
+- type: pdf
+  content: https://registry.iho.int/productspec/view.do?idx=198&product_ID=S-104&statusS=5&domainS=ALL&category=product_ID&searchValue=
+place: Monaco
+validity:
+  begins: '2023-04-10'
+contributor:
+- organization:
+    name: International Hydrographic Organization
+    abbreviation: IHO
+    url: www.iho.int
+  role: publisher
+series:
+  number: S
+  type: main
+  title:
+    type: original
+    content:
+    - content: Standards and Specifications
+      language: en
+      script: Latn
+    - content: Normes et Spécifications
+      language: fr
+      script: Latn
+  place: Monaco
+  organization: International Hydrographic Organization

--- a/data/s-111_1-2-0.yaml
+++ b/data/s-111_1-2-0.yaml
@@ -1,0 +1,67 @@
+---
+title:
+- type: main
+  content: Surface Currents Product Specification
+  language: en
+- type: main
+  content: Spécification de produit pour les courants de surface
+  language: fr
+type: standard
+editorialgroup:
+- - committee:
+      abbreviation: HSSC
+      name: Hydrographic Services and Standards Committee
+      workgroup:
+        abbreviation: TWCWG
+        name: Tides, Water Level and Currents Working Group
+docid:
+  type: IHO
+  id: S-111
+  primary: true
+docnumber: 111
+edition:
+  content: 1.2.0
+docstatus:
+  stage:
+    value: in-force
+language:
+- en
+- fr
+script: Latn
+version:
+  revision_date: '2023-03-31'
+date:
+  type: published
+  from: '2023-03-31'
+copyright:
+- owner:
+    name: International Hydrographic Organization
+    abbreviation: IHO
+    url: www.iho.int
+  from: '2023'
+link:
+- type: pdf
+  content: https://registry.iho.int/productspec/view.do?idx=178&product_ID=S-111&statusS=5&domainS=ALL&category=product_ID&searchValue=
+place: Monaco
+validity:
+  begins: '2023-03-31'
+contributor:
+- organization:
+    name: International Hydrographic Organization
+    abbreviation: IHO
+    url: www.iho.int
+  role: publisher
+series:
+  number: S
+  type: main
+  title:
+    type: original
+    content:
+    - content: Standards and Specifications
+      language: en
+      script: Latn
+    - content: Normes et Spécifications
+      language: fr
+      script: Latn
+  place: Monaco
+  organization: International Hydrographic Organization

--- a/data/s-121_1-0-0.yaml
+++ b/data/s-121_1-0-0.yaml
@@ -1,11 +1,8 @@
 ---
 title:
 - type: main
-  content: Marine Protected Areas
+  content: Maritime Limits and Boundaries
   language: en
-- type: main
-  content: Aires marines protégées
-  language: fr
 type: standard
 editorialgroup:
 - - committee:
@@ -26,13 +23,12 @@ docstatus:
     value: in-force
 language:
 - en
-- fr
 script: Latn
 version:
-  revision_date: '2019-01-01'
+  revision_date: '2019-10-29'
 date:
   type: published
-  from: '2019-01-01'
+  from: '2019-10-29'
 copyright:
 - owner:
     name: International Hydrographic Organization
@@ -41,10 +37,10 @@ copyright:
   from: '2019'
 link:
 - type: pdf
-  content: https://registry.iho.int/productspec/view.do?idx=73&product_ID=S-122
+  content: https://registry.iho.int/productspec/view.do?idx=177&product_ID=S-121
 place: Monaco
 validity:
-  begins: '2019-01-01'
+  begins: '2019-10-29'
 contributor:
 - organization:
     name: International Hydrographic Organization

--- a/data/s-122_1-0-0.yaml
+++ b/data/s-122_1-0-0.yaml
@@ -1,0 +1,67 @@
+---
+title:
+- type: main
+  content: Maritime Limits and Boundaries
+  language: en
+- type: main
+  content: Aires marines protégées
+  language: fr
+type: standard
+editorialgroup:
+- - committee:
+      abbreviation: HSSC
+      name: Hydrographic Services and Standards Committee
+      workgroup:
+        abbreviation: S-100WG
+        name: S-100 Working Group
+docid:
+  type: IHO
+  id: S-121
+  primary: true
+docnumber: 122
+edition:
+  content: 1.0.0
+docstatus:
+  stage:
+    value: in-force
+language:
+- en
+- fr
+script: Latn
+version:
+  revision_date: '2019-01-15'
+date:
+  type: published
+  from: '2019-01-15'
+copyright:
+- owner:
+    name: International Hydrographic Organization
+    abbreviation: IHO
+    url: www.iho.int
+  from: '2019'
+link:
+- type: pdf
+  content: https://registry.iho.int/productspec/view.do?idx=73&product_ID=S-122
+place: Monaco
+validity:
+  begins: '2019-01-15'
+contributor:
+- organization:
+    name: International Hydrographic Organization
+    abbreviation: IHO
+    url: www.iho.int
+  role: publisher
+series:
+  number: S
+  type: main
+  title:
+    type: original
+    content:
+    - content: Standards and Specifications
+      language: en
+      script: Latn
+    - content: Normes et Spécifications
+      language: fr
+      script: Latn
+  place: Monaco
+  organization: International Hydrographic Organization

--- a/data/s-129_1-1-0.yaml
+++ b/data/s-129_1-1-0.yaml
@@ -1,0 +1,67 @@
+---
+title:
+- type: main
+  content: Under Keel Clearance Management
+  language: en
+- type: main
+  content: Gestion de la profondeur d'eau sous quille
+  language: fr
+editorialgroup:
+- - committee:
+      abbreviation: HSSC
+      name: Hydrographic Services and Standards Committee
+      workgroup:
+        abbreviation: S-100WG
+        name: S-100 Working Group
+type: standard
+docid:
+  type: IHO
+  id: S-129
+  primary: true
+docnumber: 129
+edition:
+  content: 1.1.0
+docstatus:
+  stage:
+    value: in-force
+language:
+- en
+- fr
+script: Latn
+version:
+  revision_date: '2023-11-17'
+date:
+  type: published
+  from: '2023-11-17'
+copyright:
+- owner:
+    name: International Hydrographic Organization
+    abbreviation: IHO
+    url: www.iho.int
+  from: '2023'
+link:
+- type: pdf
+  content: https://registry.iho.int/productspec/view.do?idx=176&product_ID=S-129
+place: Monaco
+validity:
+  begins: '2023-11-17'
+contributor:
+- organization:
+    name: International Hydrographic Organization
+    abbreviation: IHO
+    url: www.iho.int
+  role: publisher
+series:
+  number: S
+  type: main
+  title:
+    type: original
+    content:
+    - content: Standards and Specifications
+      language: en
+      script: Latn
+    - content: Normes et Spécifications
+      language: fr
+      script: Latn
+  place: Monaco
+  organization: International Hydrographic Organization

--- a/data/s-44_6-1-0.yaml
+++ b/data/s-44_6-1-0.yaml
@@ -1,0 +1,75 @@
+---
+title:
+- type: main
+  content: IHO Standards for Hydrographic Surveys
+  language: en
+- type: main
+  content: Normes OHI pour les levés hydrographiques
+  language: fr
+- type: main
+  content: NORMAS DE LA OHI PARA LOS LEVANTAMIENTOS HIDROGRAFICOS
+  language: es
+- type: main
+  content: ESPECIFICAÇÕES DA OHI PARA LEVANTAMENTOS HIDROGRÁFICOS
+  language: pt
+editorialgroup:
+- - committee:
+      abbreviation: HSSC
+      name: Hydrographic Services and Standards Committee
+      workgroup:
+        abbreviation: HSPT
+        name: Project Team on Standards for Hydrographic Surveys
+type: standard
+docid:
+  type: IHO
+  id: S-44
+  primary: true
+docnumber: 44
+edition:
+  content: 6.1.0
+docstatus:
+  stage:
+    value: in-force
+language:
+- en
+- fr
+- es
+- pt
+script: Latn
+version:
+  revision_date: '2022-10-01'
+date:
+  type: published
+  from: '2022-10-01'
+copyright:
+- owner:
+    name: International Hydrographic Organization
+    abbreviation: IHO
+    url: www.iho.int
+  from: '2022'
+link:
+- type: pdf
+  content: https://iho.int/uploads/user/pubs/standards/s-44/S-44_5E.pdf
+place: Monaco
+validity:
+  begins: '2022-10-01'
+contributor:
+- organization:
+    name: International Hydrographic Organization
+    abbreviation: IHO
+    url: www.iho.int
+  role: publisher
+series:
+  number: S
+  type: main
+  title:
+    type: original
+    content:
+    - content: Standards and Specifications
+      language: en
+      script: Latn
+    - content: Normes et Spécifications
+      language: fr
+      script: Latn
+  place: Monaco
+  organization: International Hydrographic Organization

--- a/data/s-49_2-1-0.yaml
+++ b/data/s-49_2-1-0.yaml
@@ -1,0 +1,67 @@
+---
+title:
+- type: main
+  content: STANDARDIZATION of MARINERS' ROUTEING GUIDES
+  language: en
+- type: main
+  content: Normalisation des guides d’organisation du trafic pour les navigateurs
+  language: fr
+editorialgroup:
+- - committee:
+      abbreviation: HSSC
+      name: Hydrographic Services and Standards Committee
+      workgroup:
+        abbreviation: CSPCWG
+        name: NAUTICAL CARTOGRAPHY WORKING GROUP
+type: standard
+docid:
+  type: IHO
+  id: S-49
+  primary: true
+docnumber: 49
+edition:
+  content: 2.1.0
+docstatus:
+  stage:
+    value: in-force
+language:
+- en
+- fr
+script: Latn
+version:
+  revision_date: '2020-09-01'
+date:
+  type: published
+  from: '2020-09-01'
+copyright:
+- owner:
+    name: International Hydrographic Organization
+    abbreviation: IHO
+    url: www.iho.int
+  from: '2020'
+link:
+- type: pdf
+  content: https://iho.int/uploads/user/pubs/standards/s-49/S-49_Ed.2.1.0_Standardization%20of%20Mariners%20Routeing%20Guides_EN.pdf
+place: Monaco
+validity:
+  begins: '2020-09-01'
+contributor:
+- organization:
+    name: International Hydrographic Organization
+    abbreviation: IHO
+    url: www.iho.int
+  role: publisher
+series:
+  number: S
+  type: main
+  title:
+    type: original
+    content:
+    - content: Standards and Specifications
+      language: en
+      script: Latn
+    - content: Normes et Spécifications
+      language: fr
+      script: Latn
+  place: Monaco
+  organization: International Hydrographic Organization

--- a/data/s-4_4-9-0.yaml
+++ b/data/s-4_4-9-0.yaml
@@ -1,0 +1,71 @@
+---
+title:
+- type: main
+  content: REGULATIONS OF THE IHO FOR INTERNATIONAL (INT) CHARTS AND CHART SPECIFICATIONS
+    OF THE IHO
+  language: en
+- type: main
+  content: RÈGLEMENT DE L’OHI POUR LES CARTES MARINES INTERNATIONALES (INT) ET SPÉCIFICATIONS
+    DE L’OHI POUR LES CARTES MARINES
+  language: fr
+- type: main
+  content: REGLAMENTO DE LA OHI PARA CARTAS INTERNACIONALES Y ESPECIFICACIONES CARTOGRÁFICA
+    DE LA OHI
+  language: es
+editorialgroup:
+- - committee:
+      abbreviation: HSSC
+      name: Hydrographic Services and Standards Committee
+      workgroup:
+        abbreviation: NCWG
+        name: NAUTICAL CARTOGRAPHY WORKING GROUP
+type: standard
+docid:
+  type: IHO
+  id: S-4
+  primary: true
+docnumber: 4
+edition:
+  content: 4.9.0
+docstatus:
+  stage:
+    value: in-force
+language:
+- en
+- fr
+- es
+script: Latn
+version:
+  revision_date: '2021-03-01'
+date:
+  type: published
+  from: '2021-04-01'
+copyright:
+- owner:
+    name: International Hydrographic Organization
+    abbreviation: IHO
+    url: www.iho.int
+  from: '2018'
+place: Monaco
+validity:
+  begins: '2021-03-01'
+contributor:
+- organization:
+    name: International Hydrographic Organization
+    abbreviation: IHO
+    url: www.iho.int
+  role: publisher
+series:
+  number: S
+  type: main
+  title:
+    type: original
+    content:
+    - content: Standards and Specifications
+      language: en
+      script: Latn
+    - content: Normes et Spécifications
+      language: fr
+      script: Latn
+  place: Monaco
+  organization: International Hydrographic Organization

--- a/data/s-58_7-0-0.yaml
+++ b/data/s-58_7-0-0.yaml
@@ -1,0 +1,67 @@
+---
+title:
+- type: main
+  content: ENC VALIDATION CHECKS
+  language: en
+- type: main
+  content: Vérifications pour la validation des ENC
+  language: fr
+editorialgroup:
+- committee:
+    abbreviation: IMO MSC
+    name: Maritime Safety Committee
+    committee:
+      abbreviation: NCSR
+      name: Sub-Committee on Navigation, Communications and Search and Rescue
+type: standard
+docid:
+  type: IHO
+  id: S-58
+  primary: true
+docnumber: 58
+edition:
+  content: 7.0.0
+docstatus:
+  stage:
+    value: in-force
+language:
+- en
+- fr
+script: Latn
+version:
+  revision_date: '2022-10-01'
+date:
+  type: published
+  from: '2022-10-01'
+copyright:
+- owner:
+    name: International Hydrographic Organization
+    abbreviation: IHO
+    url: www.iho.int
+  from: '2022'
+link:
+- type: pdf
+  content: https://iho.int/uploads/user/pubs/standards/s-58/S-58%20Ed%207.0.0_Final.pdf
+place: Monaco
+validity:
+  begins: '2022-10-01'
+contributor:
+- organization:
+    name: International Hydrographic Organization
+    abbreviation: IHO
+    url: www.iho.int
+  role: publisher
+series:
+  number: S
+  type: main
+  title:
+    type: original
+    content:
+    - content: Standards and Specifications
+      language: en
+      script: Latn
+    - content: Normes et Spécifications
+      language: fr
+      script: Latn
+  place: Monaco
+  organization: International Hydrographic Organization

--- a/data/s-62_1-1-0.yaml
+++ b/data/s-62_1-1-0.yaml
@@ -32,7 +32,7 @@ language:
 script: Latn
 
 version:
-  revision_date: '2020-06-01'
+  revision_date: '2024-06-27'
 
 date:
   type: published
@@ -49,7 +49,7 @@ link:
   - type: html
     content: http://www.iho-ohi.net/s62/
   - type: pdf
-    content: http://www.iho-ohi.net/s62/pdfExport/pacPDFExport.php
+    content: https://registry.iho.int/producercode/ProducerCode.pdf
 
 place: Monaco
 

--- a/data/s-64_3-0-3.yaml
+++ b/data/s-64_3-0-3.yaml
@@ -1,0 +1,67 @@
+---
+title:
+- type: main
+  content: IHO Test Data Sets for ECDIS
+  language: en
+- type: main
+  content: Lot de données d'essai de l'OHI pour ECDIS
+  language: fr
+editorialgroup:
+- - committee:
+      abbreviation: HSSC
+      name: Hydrographic Services and Standards Committee
+      workgroup:
+        abbreviation: ENCWG
+        name: ENC STANDARDS MAINTENANCE WORKING GROUP
+type: standard
+docid:
+  type: IHO
+  id: S-64
+  primary: true
+docnumber: 64
+edition:
+  content: 3.0.3
+docstatus:
+  stage:
+    value: in-force
+language:
+- en
+- fr
+script: Latn
+version:
+  revision_date: '2020-12-01'
+date:
+  type: published
+  from: '2020-12-01'
+copyright:
+- owner:
+    name: International Hydrographic Organization
+    abbreviation: IHO
+    url: www.iho.int
+  from: '2020'
+link:
+- type: pdf
+  content: https://iho.int/uploads/user/pubs/standards/s-64/S-64_Download_Links_Document.pdf
+place: Monaco
+validity:
+  begins: '2020-12-01'
+contributor:
+- organization:
+    name: International Hydrographic Organization
+    abbreviation: IHO
+    url: www.iho.int
+  role: publisher
+series:
+  number: S
+  type: main
+  title:
+    type: original
+    content:
+    - content: Standards and Specifications
+      language: en
+      script: Latn
+    - content: Normes et Spécifications
+      language: fr
+      script: Latn
+  place: Monaco
+  organization: International Hydrographic Organization

--- a/data/s-99_2-0-0.yaml
+++ b/data/s-99_2-0-0.yaml
@@ -1,0 +1,69 @@
+---
+title:
+- type: main
+  content: Operational Procedures for the Organization and Management of the S-100
+    Geospatial Information Registry
+  language: en
+- type: main
+  content: Procédures opérationnelles pour l'organisation et la gestion de la base
+    de registres d'informations géospatiales de la S-100
+  language: fr
+editorialgroup:
+- - committee:
+      abbreviation: HSSC
+      name: Hydrographic Services and Standards Committee
+      workgroup:
+        abbreviation: S-100WG
+        name: S-100 Working Group
+type: standard
+docid:
+  type: IHO
+  id: S-99
+  primary: true
+docnumber: 99
+edition:
+  content: 2.0.0
+docstatus:
+  stage:
+    value: in-force
+language:
+- en
+- fr
+script: Latn
+version:
+  revision_date: '2022-10-01'
+date:
+  type: published
+  from: '2022-10-01'
+copyright:
+- owner:
+    name: International Hydrographic Organization
+    abbreviation: IHO
+    url: www.iho.int
+  from: '2022'
+link:
+- type: pdf
+  content: https://iho.int/uploads/user/pubs/standards/s-99/S-99_Ed1.1.0_Nov12_EN.pdf
+place: Monaco
+validity:
+  begins: '2022-10-01'
+contributor:
+- organization:
+    name: International Hydrographic Organization
+    abbreviation: IHO
+    url: www.iho.int
+  role: publisher
+series:
+  number: S
+  type: main
+  title:
+    type: original
+    content:
+    - content: Standards and Specifications
+      language: en
+      script: Latn
+    - content: Normes et Spécifications
+      language: fr
+      script: Latn
+  place: Monaco
+  organization: International Hydrographic Organization


### PR DESCRIPTION
Fixes https://github.com/relaton/relaton-data-iho/issues/27

I went through every bibliographic item in data/ folder and searched for new editions.
I added several new editions (as YAML files) and updated a few exiting editions.

Log of changes:

- B-12 -- added ed. 3.0.0
- B-7 -- missing item, can't find a document related.
- C-17 -- added ed. 3.0.0
- M-1 -- added ed. 2.1.1, 2.1.2, and 2.1.3
- M-3_2-0-0 -- file updated
- M-7 -- added ed 9.0.0
- P-5 -- updated revision date
- P-6 -- added third session
- P-7 -- added 1.0.7 and 1.0.8
- S-111 -- added 1.2.0
- S-121_1-0-0 -- Updated/fixed
- S-122_1-0-0 -- new file added
- S-129 -- added ed. 1.1.0
- S-32_1-0-0 -- Not sure what to do here. There is an update but electronic. No version is shown.
- S-44 -- added ed. 6.1.0
- S-49 -- added ed. 2.1.0
- S-4 -- added ed. 4.9.0
- S-58 -- added ed. 7.0.0
- S-62_1-1-0 -- updated revision_date
- S-64 -- added ed. 3.0.3
- S-99 -- added ed. 2.0.0

Note: S-65 - Annex B was not included for being "released for implementation and testing purposes only."